### PR TITLE
fetch iterator immmediately when first suscriber attaches

### DIFF
--- a/lib/convoy/queue.ex
+++ b/lib/convoy/queue.ex
@@ -149,6 +149,7 @@ defmodule Convoy.Queue do
       %{stream: opts.stream, handler_id: handler_id}
     )
 
+    send(self(), :poll)
     {:noreply, {queue, %{opts | handlers: new_handlers}}}
   end
 

--- a/lib/convoy/queue.ex
+++ b/lib/convoy/queue.ex
@@ -149,8 +149,9 @@ defmodule Convoy.Queue do
       %{stream: opts.stream, handler_id: handler_id}
     )
 
-    send(self(), :poll)
-    {:noreply, {queue, %{opts | handlers: new_handlers}}}
+    IO.puts("GETTING RECORDS")
+    {_records, new_state} = get_records(10, {queue, %{opts | handlers: new_handlers}})
+    {:noreply, new_state}
   end
 
   def handle_cast({:detach, handler_id}, {queue, opts}) do

--- a/lib/convoy/queue.ex
+++ b/lib/convoy/queue.ex
@@ -149,7 +149,6 @@ defmodule Convoy.Queue do
       %{stream: opts.stream, handler_id: handler_id}
     )
 
-    IO.puts("GETTING RECORDS")
     {_records, new_state} = get_records(10, {queue, %{opts | handlers: new_handlers}})
     {:noreply, new_state}
   end


### PR DESCRIPTION
When the first subscriber attaches, it's important to fetch the shard iterator immediately.  If we wait until the next scheduled poll then we may miss events that arrive before the new iterator is fetched.  

This takes the simple approach of forcing a poll to occur immediately.  

An alternative approach might be to separate the shard iterator fetch from the poll so that we can fetch the shard iterator immediately and then wait for the next regular poll to occur.